### PR TITLE
Fix macOS support

### DIFF
--- a/bindings.lisp
+++ b/bindings.lisp
@@ -76,7 +76,7 @@
    #:ts-node-parse-state
    #:ts-node-next-parse-state
    #:ts-node-parent
-   #:ts-node-child-containint-descendant
+   #:ts-node-child-with-descendant
    #:ts-node-child
    #:ts-node-field-name-for-child
    #:ts-node-child-count
@@ -630,7 +630,7 @@ Prefer [`ts_node_child_containing_descendant`] for
 iterating over the node's ancestors."
   (node (:pointer (:struct ts-node))))
 
-(defcfun ("ts_node_child_containing_descendant_" ts-node-child-containint-descendant) (:pointer (:struct ts-node))
+(defcfun ("ts_node_child_with_descendant_" ts-node-child-with-descendant) (:pointer (:struct ts-node))
   "Get the node's child that contains `descendant`."
   (node (:pointer (:struct ts-node)))
   (descendant (:pointer (:struct ts-node))))

--- a/shim.c
+++ b/shim.c
@@ -165,11 +165,11 @@ TSNode *ts_node_parent_(TSNode *self)
 	return node;
 }
 
-TSNode *ts_node_child_containing_descendant_(TSNode *self, TSNode *descendant)
+TSNode *ts_node_child_with_descendant_(TSNode *self, TSNode *descendant)
 {
 	TSNode *node = malloc(sizeof(TSNode));
 	if (node)
-		*node = ts_node_child_containing_descendant(*self, *descendant);
+		*node = ts_node_child_with_descendant(*self, *descendant);
 	return node;
 }
 

--- a/t/test-bindings.lisp
+++ b/t/test-bindings.lisp
@@ -6,7 +6,8 @@
   :description "Tests for treesitter low-level bindings.")
 (in-suite :treesitter/bindings)
 
-(cffi:use-foreign-library "libtree-sitter-c.so")
+(cffi:use-foreign-library #-darwin "libtree-sitter-c.so"
+                          #+darwin "libtree-sitter-c.dylib")
 (cffi:defcfun "tree_sitter_c" :pointer)
 (defvar *c-lang* (tree-sitter-c))
 

--- a/treesitter.lisp
+++ b/treesitter.lisp
@@ -458,7 +458,10 @@ Returns a list of nodes."
 Interns a function named `tree-sitter-*` that creates a language."
   (let ((fn-symbol (intern (format nil "~:@(tree-sitter-~a~)" lang) :treesitter)))
     `(progn
-       (cffi:load-foreign-library ,(format nil "libtree-sitter-~(~a~).so" lang)
+       (cffi:load-foreign-library ,(format nil
+                                           #-darwin "libtree-sitter-~(~a~).so"
+                                           #+darwin "libtree-sitter-~(~a~).dylib"
+                                           lang)
                                   :search-path (or ,search-path *language-path*))
        (cffi:defcfun (,(format nil "tree_sitter_~(~a~)" lang) ,fn-symbol) :pointer)
        (setf (gethash ,lang *languages*) (quote ,fn-symbol)))))


### PR DESCRIPTION
The commit contains 2 changes, after changes the library have passed the test on SBCL 2.5.0 and LispWorks 8.0.1 on macOS Sequoia 15.3.1 with Apple M3 chip.

- Using `.dylib` instead of `.so` on `include-language` macro and test file
- `ts-node-child-containint-descendant` has been removed from upstream [in a recent commit](https://github.com/tree-sitter/tree-sitter/commit/344a88c4fb968cc789049a378e0cc988c4253751), with `ts_node_child_with_descendant` for replacement. The `tree-sitter` homebrew formula has updated with this change. Original binding will raise an compilation error.

We suggest trying to test the new API on your machine, since the package managers have different speed for updating the library.